### PR TITLE
Fix Chromium scrollbar bug

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -282,11 +282,13 @@ footer {
   height: 12px;
 }
 
-:is(::selection, ::-webkit-scrollbar-thumb:hover) {
+::selection,
+::-webkit-scrollbar-thumb:hover {
   background-color: var(--clr-brand);
 }
 
-:is(::-webkit-scrollbar-thumb, ::selection:window-inactive) {
+::selection:window-inactive,
+::-webkit-scrollbar-thumb {
   background: var(--clr-brand-transparent);
 }
 


### PR DESCRIPTION
- Custom scrollbar would not show with the use of the `is:()` pseudo-class